### PR TITLE
Fix/compatability with latest postgres

### DIFF
--- a/cdb4/ddl_scripts/postgresql/010_functions.sql
+++ b/cdb4/ddl_scripts/postgresql/010_functions.sql
@@ -2750,7 +2750,9 @@ perform_snapping 	integer DEFAULT 0, 			-- i.e. default is 0 ("do nothing"), oth
 digits 				integer DEFAULT 3,			-- number of digits after comma for precision
 area_min			numeric DEFAULT 0.0001 		-- minimum acceptable area of a polygon 
 )
-RETURNS geometry AS $$
+RETURNS geometry 
+SET search_path TO public, pg_catalog, pg_temp
+AS $$
 DECLARE
 dec_prec 		numeric;
 srid_id 		integer;

--- a/cdb4/ddl_scripts/postgresql/080_layers_bridge.sql
+++ b/cdb4/ddl_scripts/postgresql/080_layers_bridge.sql
@@ -1387,7 +1387,8 @@ sql_layer := concat(sql_layer,'
 		INNER JOIN ',qi_cdb_schema,'.surface_geometry AS sg ON (sg.root_id = ig.relative_brep_id AND sg.implicit_geometry IS NOT NULL)
 	WHERE
 		o.',t.lodx_label,'_implicit_rep_id IS NOT NULL
-	GROUP BY o.id;
+	GROUP BY o.id
+WITH NO DATA;
 COMMENT ON MATERIALIZED VIEW ',qi_usr_schema,'.',qi_gv_name,' IS ''Mat. view of (',r.class_name,') ',s.class_name,' ',t.lodx_name,' in schema ',qi_cdb_schema,''';
 ',qgis_pkg.generate_sql_matview_footer(qi_usr_name, qi_usr_schema, ql_l_name, qi_gv_name));
 


### PR DESCRIPTION
PostgreSQL version 17 breaks the plugin (see issue #71) 

Version 17 introduced the following:

_Change functions to use a safe [search_path](https://www.postgresql.org/docs/17/runtime-config-client.html#GUC-SEARCH-PATH) during maintenance operations (Jeff Davis) [§](https://postgr.es/c/2af07e2f7) [§](https://postgr.es/c/b4da732fd64)
This prevents maintenance operations (ANALYZE, CLUSTER, CREATE INDEX, CREATE MATERIALIZED VIEW, REFRESH MATERIALIZED VIEW, REINDEX, or VACUUM) from performing unsafe access. Functions used by expression indexes and materialized views that need to reference non-default schemas must specify a search path during function creation._

For us this meant that functions that are part of a `REFRESH MATERIALIZED VIEW` operation like `st_snap_poly_to_grid` can no longer find PostGIS types (geometry) from the public schema because the path is temporarily changed to only include pg_catalog and pg_temp.

As suggested the solution is to set the 'extra' schema in the function definition